### PR TITLE
accumulate over count, instead of taking it as an absolute offset

### DIFF
--- a/pyflare/client.py
+++ b/pyflare/client.py
@@ -70,7 +70,7 @@ class PyflareClient(object):
                 'z': zone
             })
             has_more = records['response']['recs']['has_more']
-            current_count = records['response']['recs']['count']
+            current_count += records['response']['recs']['count']
             for record in records['response']['recs']['objs']:
                 yield record
 


### PR DESCRIPTION
records['response']['recs']['count'] is the number of items in the latest batch
of records, but it was treated as thought it was an absolute offset within the
list of all records.

This would manifest as an infinite loop whenever you get more than two batches.