### PR TITLE
bugfix: exception raised when zone had no records

### DIFF
--- a/pyflare/client.py
+++ b/pyflare/client.py
@@ -69,10 +69,13 @@ class PyflareClient(object):
                 'o': current_count,
                 'z': zone
             })
-            has_more = records['response']['recs']['has_more']
-            current_count += records['response']['recs']['count']
-            for record in records['response']['recs']['objs']:
-                yield record
+            try:
+                has_more = records['response']['recs']['has_more']
+                current_count += records['response']['recs']['count']
+                for record in records['response']['recs']['objs']:
+                    yield record
+            except KeyError:
+                has_more = False
 
     def zone_check(self, zones):
         """

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ packages = find_packages(exclude=['tests", "tests.*'])
 
 setup(
     name='pyflare',
-    version='1.1.1',
+    version='1.1.2',
     packages=packages,
     url='https://github.com/jlinn/pyflare',
     license='LICENSE.txt',


### PR DESCRIPTION
Fixes a bug that presents itself when you use `rec_load_all` on a zone with no records. The JSON response does not contain the fields this method uses to calculate when it should stop attempting to yield records, and results in a nasty `KeyError` instead of just returning nothing like it probably should.